### PR TITLE
상품 도메인을 개선하라

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,6 @@
+lombok.Setter.flagUsage = error
+lombok.AllArgsConstructor.flagUsage = error
+lombok.ToString.flagUsage = warning
+lombok.data.flagUsage= error
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/com/dddkurlyclone/product/App.java
+++ b/src/main/java/com/dddkurlyclone/product/App.java
@@ -1,19 +1,11 @@
 package com.dddkurlyclone.product;
 
-import com.github.dozermapper.core.DozerBeanMapperBuilder;
-import com.github.dozermapper.core.Mapper;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class App {
   public static void main(String[] args) {
     SpringApplication.run(App.class, args);
-  }
-
-  @Bean
-  public Mapper dozerMapper() {
-    return DozerBeanMapperBuilder.buildDefault();
   }
 }

--- a/src/main/java/com/dddkurlyclone/product/config/DozerMapperConfig.java
+++ b/src/main/java/com/dddkurlyclone/product/config/DozerMapperConfig.java
@@ -1,0 +1,14 @@
+package com.dddkurlyclone.product.config;
+
+import com.github.dozermapper.core.DozerBeanMapperBuilder;
+import com.github.dozermapper.core.Mapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DozerMapperConfig {
+    @Bean
+    public Mapper dozerMapper() {
+        return DozerBeanMapperBuilder.buildDefault();
+    }
+}

--- a/src/main/java/com/dddkurlyclone/product/config/JpaConfig.java
+++ b/src/main/java/com/dddkurlyclone/product/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.dddkurlyclone.product.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+}

--- a/src/main/java/com/dddkurlyclone/product/domain/BaseTimeEntity.java
+++ b/src/main/java/com/dddkurlyclone/product/domain/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.dddkurlyclone.product.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/dddkurlyclone/product/domain/Product.java
+++ b/src/main/java/com/dddkurlyclone/product/domain/Product.java
@@ -12,7 +12,7 @@ import javax.persistence.Id;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Product {
+public class Product extends BaseTimeEntity {
   @Id @GeneratedValue
   private Long id;
 

--- a/src/main/java/com/dddkurlyclone/product/domain/Product.java
+++ b/src/main/java/com/dddkurlyclone/product/domain/Product.java
@@ -1,9 +1,13 @@
 package com.dddkurlyclone.product.domain;
 
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import lombok.*;
 
 @Entity
 @Getter

--- a/src/main/java/com/dddkurlyclone/product/domain/Product.java
+++ b/src/main/java/com/dddkurlyclone/product/domain/Product.java
@@ -7,19 +7,19 @@ import lombok.*;
 
 @Entity
 @Getter
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Product {
-  @Id @GeneratedValue private Long id;
+  @Id @GeneratedValue
+  private Long id;
 
   private String name;
 
   private Integer price;
 
+  @Builder
   public Product(Long id, String name, Integer price) {
     this.id = id;
     this.name = name;
     this.price = price;
   }
-
-  public Product() {}
 }

--- a/src/main/java/com/dddkurlyclone/product/dto/ProductData.java
+++ b/src/main/java/com/dddkurlyclone/product/dto/ProductData.java
@@ -5,6 +5,7 @@ import javax.validation.constraints.NotBlank;
 import lombok.*;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductData {
   private Long id;
 
@@ -16,8 +17,7 @@ public class ProductData {
   @Mapping("price")
   private Integer price;
 
-  public ProductData() {}
-
+  @Builder
   public ProductData(Long id, String name, Integer price) {
     this.id = id;
     this.name = name;

--- a/src/main/java/com/dddkurlyclone/product/dto/ProductData.java
+++ b/src/main/java/com/dddkurlyclone/product/dto/ProductData.java
@@ -1,8 +1,12 @@
 package com.dddkurlyclone.product.dto;
 
 import com.github.dozermapper.core.Mapping;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import javax.validation.constraints.NotBlank;
-import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)


### PR DESCRIPTION
### 1. 롬복 제한 파일 추가

롬복에서 데이터 정합성을 해칠 수 있는 `Setter` , `AllArgsConstructor`, `ToString`, `Data`는 사용하지 못하도록 추가합니다.

```java
lombok.Setter.flagUsage = error
lombok.AllArgsConstructor.flagUsage = error
lombok.ToString.flagUsage = warning
lombok.data.flagUsage= error
config.stopBubbling = true
lombok.addLombokGeneratedAnnotation = true
```

---

### 2. dozermapper 분리

`App.class`에 있으면 못보고 지나치기 쉽기 때문에 따로 빈으로 등록합니다.

```java
@Configuration
public class DozerMapperConfig {
    @Bean
    public Mapper dozerMapper() {
        return DozerBeanMapperBuilder.buildDefault();
    }
}
```

---

### 3. import * 제거하기

`import lombok.*`은 불필요한 롬복까지 추가하므로 사용하는 것만 개별적으로 설정합니다.


![image](https://user-images.githubusercontent.com/45138206/137160166-22573e49-0aa7-4df3-8345-cbd4d1242d7a.png)

`File - Settings - Imports 탭 `에서 `*`를 사용하지 않기 위해 2개를 999로 설정합니다.  


``` java
import lombok.AccessLevel;
import lombok.Builder;
import lombok.Getter;
import lombok.NoArgsConstructor;
```

---

### 4. BaseTimeEntity 추가

```java
@Getter
@MappedSuperclass
@EntityListeners(AuditingEntityListener.class)
public abstract class BaseTimeEntity {
    @CreatedDate
    @Column(updatable = false)
    private LocalDateTime createdAt;

    @LastModifiedDate
    @Column
    private LocalDateTime updatedAt;
}
```

`Product`는 `BaseTimeEntity`를 상속하면 생성시간과 수정시간을 자동으로 넣어주는 기능을 사용할 수 있습니다.

```java
...
public class Product extends BaseTimeEntity {
...
```
